### PR TITLE
Create the script folder if it does not exist

### DIFF
--- a/Undo-WinRMConfig.ps1
+++ b/Undo-WinRMConfig.ps1
@@ -131,6 +131,7 @@ Function Setup-Undo {
   $scriptfilename = (Split-Path -leaf $scriptpath)
   $ScriptFolder = (Split-Path -parent $scriptpath)
   $FileContents = Get-Variable -name "Pristine-WSMan-${OSMajorMinorVersionString}.reg" -ValueOnly
+  New-Item -ItemType Directory -Force -Path $ScriptFolder
   Set-Content -Path "$ScriptFolder\Pristine-WSMan-${OSMajorMinorVersionString}.reg" -Value $FileContents
 
   $selfdeletescript = @"


### PR DESCRIPTION
When creating the script for shutdown, parts of the Group Policy path may not exist. `Set-Content` fails if any of the intermediate directories do not exist.

To fix this, use a `New-Item` with `-Force` to make any missing intermediate directories.